### PR TITLE
Hotfix/variable wind parse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mivek</groupId>
 	<artifactId>metarParser</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 	<name>metarParser</name>
 	<description>This project is a metar parser.
 Use the ParseController class to parse a metar and retrieve a metar object.</description>

--- a/src/main/java/com/mivek/model/Wind.java
+++ b/src/main/java/com/mivek/model/Wind.java
@@ -18,7 +18,7 @@ public class Wind {
 	/**
 	 * Direction of the wind
 	 */
-	private int directionDegrees;
+	private Integer directionDegrees;
 	/**
 	 * The speed of the gust.
 	 */
@@ -153,7 +153,7 @@ public class Wind {
 	/**
 	 * @return the directionDegrees.
 	 */
-	public int getDirectionDegrees() {
+	public Integer getDirectionDegrees() {
 		return directionDegrees;
 	}
 
@@ -161,7 +161,7 @@ public class Wind {
 	 * @param pDirectionDegrees
 	 *            the directionDegrees to set.
 	 */
-	public void setDirectionDegrees(final int pDirectionDegrees) {
+	public void setDirectionDegrees(final Integer pDirectionDegrees) {
 		directionDegrees = pDirectionDegrees;
 	}
 

--- a/src/main/java/com/mivek/parser/AbstractParser.java
+++ b/src/main/java/com/mivek/parser/AbstractParser.java
@@ -2,6 +2,7 @@
  * 
  */
 package com.mivek.parser;
+
 import com.mivek.enums.*;
 import com.mivek.model.*;
 import com.mivek.utils.Converter;

--- a/src/main/java/com/mivek/parser/AbstractParser.java
+++ b/src/main/java/com/mivek/parser/AbstractParser.java
@@ -10,20 +10,13 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.mivek.enums.CloudQuantity;
-import com.mivek.enums.CloudType;
-import com.mivek.enums.Descriptive;
-import com.mivek.enums.Intensity;
-import com.mivek.enums.Phenomenon;
-import com.mivek.model.Airport;
-import com.mivek.model.Cloud;
-import com.mivek.model.Country;
-import com.mivek.model.WeatherCode;
-import com.mivek.model.WeatherCondition;
-import com.mivek.model.Wind;
+import com.mivek.enums.*;
+import com.mivek.model.*;
 import com.mivek.utils.Converter;
 import com.mivek.utils.Regex;
 import com.opencsv.CSVReader;
+
+import i18n.Messages;
 
 /**
  * @author mivek
@@ -43,7 +36,7 @@ public abstract class AbstractParser<T extends WeatherCode> {
 	/**
 	 * Pattern regex for wind.
 	 */
-	protected static final String WIND_REGEX = "(\\d{3})(\\d{2})G?(\\d{2})?(KT|MPS|KM\\/H)";
+	protected static final String WIND_REGEX = "(\\w{3})(\\d{2})G?(\\d{2})?(KT|MPS|KM\\/H)";
 	/**
 	 * Pattern regex for extreme winds.
 	 */
@@ -139,8 +132,12 @@ public abstract class AbstractParser<T extends WeatherCode> {
 	protected Wind parseWind(final String pStringWind) {
 		Wind wind = new Wind();
 		String[] windPart = Regex.pregMatch(WIND_REGEX, pStringWind);
-		wind.setDirection(Converter.degreesToDirection(windPart[1]));
-		wind.setDirectionDegrees(Integer.parseInt(windPart[1]));
+		String directionPart = windPart[1];
+		String direction = Converter.degreesToDirection(directionPart);
+		wind.setDirection(direction);
+		if (!direction.equals(Messages.CONVERTER_VRB)) {
+			wind.setDirectionDegrees(Integer.parseInt(windPart[1]));
+		}
 		wind.setSpeed(Integer.parseInt(windPart[2]));
 		if (windPart[3] != null) {
 			wind.setGust(Integer.parseInt(windPart[3]));

--- a/src/main/java/com/mivek/parser/AbstractParser.java
+++ b/src/main/java/com/mivek/parser/AbstractParser.java
@@ -2,6 +2,13 @@
  * 
  */
 package com.mivek.parser;
+import com.mivek.enums.*;
+import com.mivek.model.*;
+import com.mivek.utils.Converter;
+import com.mivek.utils.Regex;
+import com.opencsv.CSVReader;
+
+import i18n.Messages;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -10,13 +17,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.mivek.enums.*;
-import com.mivek.model.*;
-import com.mivek.utils.Converter;
-import com.mivek.utils.Regex;
-import com.opencsv.CSVReader;
-
-import i18n.Messages;
 
 /**
  * @author mivek

--- a/src/test/java/com/mivek/parser/AbstractParserTest.java
+++ b/src/test/java/com/mivek/parser/AbstractParserTest.java
@@ -12,11 +12,7 @@ import static org.junit.Assert.assertThat;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.mivek.enums.CloudQuantity;
-import com.mivek.enums.CloudType;
-import com.mivek.enums.Descriptive;
-import com.mivek.enums.Intensity;
-import com.mivek.enums.Phenomenon;
+import com.mivek.enums.*;
 import com.mivek.model.Cloud;
 import com.mivek.model.WeatherCode;
 import com.mivek.model.WeatherCondition;
@@ -112,6 +108,15 @@ public abstract class AbstractParserTest<T extends WeatherCode> {
 		assertEquals(17, res.getSpeed());
 		assertEquals(20, res.getGust());
 		assertEquals("KT", res.getUnit());
+	}
+
+	@Test
+	public void testParseWindVariable() {
+		String windPart = "VRB08KT";
+
+		Wind res = getSut().parseWind(windPart);
+
+		assertNotNull(res);
 	}
 
 	/*

--- a/src/test/java/com/mivek/parser/AbstractParserTest.java
+++ b/src/test/java/com/mivek/parser/AbstractParserTest.java
@@ -19,7 +19,7 @@ import com.mivek.model.WeatherCondition;
 import com.mivek.model.Wind;
 
 /**
- * 
+ * Test class for {@link AbstractParser}
  * @author mivek
  *
  */
@@ -89,7 +89,7 @@ public abstract class AbstractParserTest<T extends WeatherCode> {
 
 		assertNotNull(res);
 		assertThat(res.getDirection(), is(i18n.Messages.CONVERTER_N));
-		assertEquals(340, res.getDirectionDegrees());
+		assertEquals(Integer.valueOf(340), res.getDirectionDegrees());
 		assertEquals(8, res.getSpeed());
 		assertEquals(0, res.getGust());
 		assertEquals("KT", res.getUnit());
@@ -104,7 +104,7 @@ public abstract class AbstractParserTest<T extends WeatherCode> {
 
 		assertNotNull(res);
 		assertThat(res.getDirection(), is(i18n.Messages.CONVERTER_SE));
-		assertEquals(120, res.getDirectionDegrees());
+		assertEquals(Integer.valueOf(120), res.getDirectionDegrees());
 		assertEquals(17, res.getSpeed());
 		assertEquals(20, res.getGust());
 		assertEquals("KT", res.getUnit());
@@ -117,6 +117,9 @@ public abstract class AbstractParserTest<T extends WeatherCode> {
 		Wind res = getSut().parseWind(windPart);
 
 		assertNotNull(res);
+		assertEquals(i18n.Messages.CONVERTER_VRB, res.getDirection());
+		assertEquals(8, res.getSpeed());
+		assertNull(res.getDirectionDegrees());
 	}
 
 	/*

--- a/src/test/java/com/mivek/parser/MetarParserTest.java
+++ b/src/test/java/com/mivek/parser/MetarParserTest.java
@@ -20,6 +20,7 @@ import com.mivek.model.RunwayInfo;
 import com.mivek.model.WeatherCode;
 
 /**
+ * Test class for {@link MetarParser}
  * @author mivek
  *
  */
@@ -27,6 +28,7 @@ public class MetarParserTest extends AbstractParserTest<Metar> {
 
 	private static MetarParser fSut;
 
+	@Override
 	MetarParser getSut() {
 		return fSut;
 	}

--- a/src/test/java/com/mivek/parser/TAFParserTest.java
+++ b/src/test/java/com/mivek/parser/TAFParserTest.java
@@ -31,6 +31,7 @@ import com.mivek.model.Wind;
 import com.mivek.utils.Converter;
 
 /**
+ * Test class for {@link TAFParser}
  * @author mivek
  *
  */
@@ -38,7 +39,7 @@ public class TAFParserTest extends AbstractParserTest<TAF> {
 
 	private static TAFParser fSut;
 
-
+	@Override
 	TAFParser getSut() {
 		return fSut;
 	}


### PR DESCRIPTION
This pull request fixes a the bug from #14.

When parsing a wind with variable part, an error was thrown. The problem was the regex used to parse the wind part of the metar.
The regex started with \\d{3} which matches 3 numbers but it did not matched "VRB", the wind part "VRB08KT" was not matched by the regex.
I replaced the \\{d3} by \\w{3} to fix the bug. See test in AbstractParserTest class.

I also changed the type of directionDegrees attribute in the Wind class. The type was previously an int, it is now an Integer. This change allows to have a null value in directionDegrees when the wind is VRB instead of a 0 value.