### PR TITLE
Excluded openjdk job if branch is master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: java
 env:
   global:
     - CC_TEST_REPORTER_ID=80f941339411bc7abca6636030897e70dad49f2693f1bcc14ab9fda1b86bf63d
-    
+
 jobs:
   include:
     - if: branch in (develop, master)
       jdk: oraclejdk8
-    - if: branch = develop
+    - if: branch = master
       jdk: openjdk8
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - if: branch in (develop, master)
       jdk: oraclejdk8
-    - if: branch = master
+    - if: branch = develop
       jdk: openjdk8
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ env:
 jdk:
   - oraclejdk8
   - openjdk8
+jobs:
+  exclude:
+    - if: branch = master
+      jdk: openjdk8
+
 before_install:
   # Retrieve keys only if building branch is either develop or master and not a pull request
   - if ([ "$TRAVIS_BRANCH" = "develop" ] || [ "$TRAVIS_BRANCH" = "master" ]) && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk8
 jobs:
   exclude:
-    - if: branch = master
+    - if: branch = develop
       jdk: openjdk8
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: java
 env:
   global:
     - CC_TEST_REPORTER_ID=80f941339411bc7abca6636030897e70dad49f2693f1bcc14ab9fda1b86bf63d
-jdk:
-  - oraclejdk8
-  - openjdk8
+    
 jobs:
-  exclude:
+  include:
+    - if: branch in (develop, master)
+      jdk: oraclejdk8
     - if: branch = develop
       jdk: openjdk8
 


### PR DESCRIPTION
Updated travis-ci file to exclude openjdk job when the branch build is master