### PR TITLE
taf parsing improvements

### DIFF
--- a/src/main/java/io/github/mivek/model/TAF.java
+++ b/src/main/java/io/github/mivek/model/TAF.java
@@ -18,6 +18,10 @@ import java.util.List;
 public class TAF extends AbstractWeatherCode {
     /** The valididty of the TAF. */
     private Validity validity;
+    /** The maximum temperature. */
+    private TemperatureDated maxTemperature;
+    /** The minimum temperature. */
+    private TemperatureDated minTemperature;
     /** List of BECMG changes. */
     private List<BECMGTafTrend> bECMGs;
     /** List of From changes. */
@@ -26,8 +30,6 @@ public class TAF extends AbstractWeatherCode {
     private List<TEMPOTafTrend> tempos;
     /** List of probability changes. */
     private List<PROBTafTrend> probs;
-    /** Probability of the metar. */
-    private Integer probability;
     /**Indicate if the taf event is ameded.*/
     private boolean amendment;
 
@@ -54,6 +56,34 @@ public class TAF extends AbstractWeatherCode {
      */
     public void setValidity(final Validity pValidity) {
         validity = pValidity;
+    }
+
+    /**
+     * @return the maxTemperature
+     */
+    public TemperatureDated getMaxTemperature() {
+        return maxTemperature;
+    }
+
+    /**
+     * @param pMaxTemperature the maxTemperature to set
+     */
+    public void setMaxTemperature(final TemperatureDated pMaxTemperature) {
+        maxTemperature = pMaxTemperature;
+    }
+
+    /**
+     * @return the minTemperature
+     */
+    public TemperatureDated getMinTemperature() {
+        return minTemperature;
+    }
+
+    /**
+     * @param pMinTemperature the minTemperature to set
+     */
+    public void setMinTemperature(final TemperatureDated pMinTemperature) {
+        minTemperature = pMinTemperature;
     }
 
     /**
@@ -94,21 +124,6 @@ public class TAF extends AbstractWeatherCode {
     }
 
     /**
-     * @return the probability
-     */
-    public Integer getProbability() {
-        return probability;
-    }
-
-    /**
-     * @param pProbability
-     * the probability to set
-     */
-    public void setProbability(final Integer pProbability) {
-        probability = pProbability;
-    }
-
-    /**
      * Adds a BECMG to the list.
      * @param pChange the change to add.
      */
@@ -146,8 +161,11 @@ public class TAF extends AbstractWeatherCode {
     }
 
     @Override public final String toString() {
-        return new ToStringBuilder(this).appendSuper(super.toString()).appendToString(validity.toString()).append(Messages.getInstance().getString("ToString.probability"), probability)
-                .append(Messages.getInstance().getString("ToString.amendment"), amendment).appendToString(bECMGs.toString()).appendToString(fMs.toString()).appendToString(tempos.toString())
+        return new ToStringBuilder(this).appendSuper(super.toString()).appendToString(validity.toString())
+                .append(Messages.getInstance().getString("ToString.temperature.max"), maxTemperature)
+                .append(Messages.getInstance().getString("ToString.temperature.min"), minTemperature)
+                .append(Messages.getInstance().getString("ToString.amendment"), amendment)
+                .appendToString(bECMGs.toString()).appendToString(fMs.toString()).appendToString(tempos.toString())
                 .appendToString(probs.toString()).toString();
     }
 }

--- a/src/main/java/io/github/mivek/model/trend/AbstractTafProbTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/AbstractTafProbTrend.java
@@ -1,0 +1,52 @@
+package io.github.mivek.model.trend;
+
+import io.github.mivek.enums.WeatherChangeType;
+import io.github.mivek.internationalization.Messages;
+import io.github.mivek.model.trend.validity.AbstractValidity;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Class representing a weather change with a given probability.
+ *
+ * @param <T> a concrete subclass of {@link AbstractValidity}
+ * @author f.loris
+ */
+public abstract class AbstractTafProbTrend<T extends AbstractValidity> extends AbstractTafTrend<T> {
+
+    private Integer probability;
+
+    /**
+     * Constructor with parameter.
+     *
+     * @param pType the type to set.
+     */
+    protected AbstractTafProbTrend(final WeatherChangeType pType) {
+        super(pType);
+    }
+
+
+    /**
+     * @return the probability
+     */
+    public Integer getProbability() {
+        return probability;
+    }
+
+    /**
+     * @param pProbability the probability to set
+     */
+    public void setProbability(final Integer pProbability) {
+        probability = pProbability;
+    }
+
+    /**
+     * @return A description of the object.
+     */
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).
+                appendSuper(super.toString()).
+                append(Messages.getInstance().getString("ToString.probability"), probability).
+                toString();
+    }
+}

--- a/src/main/java/io/github/mivek/model/trend/AbstractTafProbTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/AbstractTafProbTrend.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 public abstract class AbstractTafProbTrend<T extends AbstractValidity> extends AbstractTafTrend<T> {
 
+    /** Probability of the trend. */
     private Integer probability;
 
     /**

--- a/src/main/java/io/github/mivek/model/trend/AbstractTafTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/AbstractTafTrend.java
@@ -14,12 +14,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public abstract class AbstractTafTrend<T extends AbstractValidity> extends AbstractTrend {
     /** The validity of the change. */
     private T validity;
-    /** The probability of the change. */
-    private Integer probability;
-    /** The maximum temperature. */
-    private TemperatureDated maxTemperature;
-    /** The minimum temperature. */
-    private TemperatureDated minTemperature;
 
     /**
      * Constructor with parameter.
@@ -45,57 +39,12 @@ public abstract class AbstractTafTrend<T extends AbstractValidity> extends Abstr
 
 
     /**
-     * @return the probability
-     */
-    public Integer getProbability() {
-        return probability;
-    }
-
-    /**
-     * @param pProbability the probability to set
-     */
-    public void setProbability(final Integer pProbability) {
-        probability = pProbability;
-    }
-
-    /**
-     * @return the maxTemperature
-     */
-    public TemperatureDated getMaxTemperature() {
-        return maxTemperature;
-    }
-
-    /**
-     * @param pMaxTemperature the maxTemperature to set
-     */
-    public void setMaxTemperature(final TemperatureDated pMaxTemperature) {
-        maxTemperature = pMaxTemperature;
-    }
-
-    /**
-     * @return the minTemperature
-     */
-    public TemperatureDated getMinTemperature() {
-        return minTemperature;
-    }
-
-    /**
-     * @param pMinTemperature the minTemperature to set
-     */
-    public void setMinTemperature(final TemperatureDated pMinTemperature) {
-        minTemperature = pMinTemperature;
-    }
-
-    /**
      * @return A description of the object.
      */
     @Override public String toString() {
         return new ToStringBuilder(this).
                 appendSuper(super.toString()).
                 appendToString(validity.toString()).
-                append(Messages.getInstance().getString("ToString.probability"), probability).
-                append(Messages.getInstance().getString("ToString.temperature.max"), maxTemperature).
-                append(Messages.getInstance().getString("ToString.temperature.min"), minTemperature).
                 toString();
     }
 }

--- a/src/main/java/io/github/mivek/model/trend/AbstractTafTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/AbstractTafTrend.java
@@ -1,8 +1,6 @@
 package io.github.mivek.model.trend;
 
 import io.github.mivek.enums.WeatherChangeType;
-import io.github.mivek.internationalization.Messages;
-import io.github.mivek.model.TemperatureDated;
 import io.github.mivek.model.trend.validity.AbstractValidity;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 

--- a/src/main/java/io/github/mivek/model/trend/PROBTafTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/PROBTafTrend.java
@@ -6,7 +6,7 @@ import io.github.mivek.model.trend.validity.Validity;
 /**
  * @author mivek
  */
-public class PROBTafTrend extends AbstractTafTrend<Validity> {
+public class PROBTafTrend extends AbstractTafProbTrend<Validity> {
 
     /**
      * Constructor.

--- a/src/main/java/io/github/mivek/model/trend/TEMPOTafTrend.java
+++ b/src/main/java/io/github/mivek/model/trend/TEMPOTafTrend.java
@@ -7,7 +7,7 @@ import io.github.mivek.model.trend.validity.Validity;
  * Class representing a Tempo change in a taf message.
  * @author mivek
  */
-public final class TEMPOTafTrend extends AbstractTafTrend<Validity> {
+public final class TEMPOTafTrend extends AbstractTafProbTrend<Validity> {
     /**
      * Default constructor.
      */

--- a/src/main/java/io/github/mivek/parser/TAFParser.java
+++ b/src/main/java/io/github/mivek/parser/TAFParser.java
@@ -7,7 +7,11 @@ import io.github.mivek.exception.ParseException;
 import io.github.mivek.model.Airport;
 import io.github.mivek.model.TAF;
 import io.github.mivek.model.TemperatureDated;
-import io.github.mivek.model.trend.*;
+import io.github.mivek.model.trend.AbstractTafTrend;
+import io.github.mivek.model.trend.BECMGTafTrend;
+import io.github.mivek.model.trend.FMTafTrend;
+import io.github.mivek.model.trend.PROBTafTrend;
+import io.github.mivek.model.trend.TEMPOTafTrend;
 import io.github.mivek.model.trend.validity.BeginningValidity;
 import io.github.mivek.model.trend.validity.Validity;
 import io.github.mivek.utils.Converter;
@@ -27,9 +31,9 @@ public final class TAFParser extends AbstractParser<TAF> {
     public static final String TAF = "TAF";
     /** Probability string constant. */
     private static final String PROB = "PROB";
-    /** Temperature Maximum Constant */
+    /** Temperature Maximum Constant. */
     private static final String TX = "TX";
-    /** Temperature Minimum Constant */
+    /** Temperature Minimum Constant. */
     private static final String TN = "TN";
     /** Regex for the validity. */
     private static final Pattern REGEX_VALIDITY = Pattern.compile("^\\d{4}/\\d{4}$");
@@ -117,7 +121,7 @@ public final class TAFParser extends AbstractParser<TAF> {
     }
 
     /**
-     * Extracts all lines and tokenize them
+     * Extracts all lines and tokenize them.
      * @param pTAFCode raw TAF which may already contains some linebreaks
      * @return 2d jagged array containing lines and their tokens
      */
@@ -207,8 +211,8 @@ public final class TAFParser extends AbstractParser<TAF> {
     /**
      * parses the probability out of PROB??
      *
-     * @param pPart
-     * @return
+     * @param pPart the string to parse.
+     * @return probability of the trend.
      */
     protected int parseProbability(final String pPart) {
         return Integer.parseInt(pPart.substring(4));

--- a/src/main/java/io/github/mivek/parser/TAFParser.java
+++ b/src/main/java/io/github/mivek/parser/TAFParser.java
@@ -7,17 +7,17 @@ import io.github.mivek.exception.ParseException;
 import io.github.mivek.model.Airport;
 import io.github.mivek.model.TAF;
 import io.github.mivek.model.TemperatureDated;
-import io.github.mivek.model.trend.AbstractTafTrend;
-import io.github.mivek.model.trend.BECMGTafTrend;
-import io.github.mivek.model.trend.FMTafTrend;
-import io.github.mivek.model.trend.PROBTafTrend;
-import io.github.mivek.model.trend.TEMPOTafTrend;
+import io.github.mivek.model.trend.*;
 import io.github.mivek.model.trend.validity.BeginningValidity;
 import io.github.mivek.model.trend.validity.Validity;
 import io.github.mivek.utils.Converter;
 import io.github.mivek.utils.Regex;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author mivek
@@ -27,6 +27,10 @@ public final class TAFParser extends AbstractParser<TAF> {
     public static final String TAF = "TAF";
     /** Probability string constant. */
     private static final String PROB = "PROB";
+    /** Temperature Maximum Constant */
+    private static final String TX = "TX";
+    /** Temperature Minimum Constant */
+    private static final String TN = "TN";
     /** Regex for the validity. */
     private static final Pattern REGEX_VALIDITY = Pattern.compile("^\\d{4}/\\d{4}$");
     /** Instance of the TAFParser. */
@@ -62,14 +66,14 @@ public final class TAFParser extends AbstractParser<TAF> {
      */
     @Override
     public TAF parse(final String pTAFCode) throws ParseException {
-        String[] lines = pTAFCode.split("\n");
-        if (!TAF.equals(lines[0].substring(0, 3))) {
+        String[][] lines = extractLineTokens(pTAFCode);
+        if (!TAF.equals(lines[0][0])) {
             throw new ParseException(ErrorCodes.ERROR_CODE_INVALID_MESSAGE);
         }
         TAF taf = new TAF();
 
         // Handle the 1st line.
-        String[] line1parts = tokenize(lines[0]);
+        String[] line1parts = lines[0];
         int i = 1;
         if (TAF.equals(line1parts[1])) {
             i = 2;
@@ -92,21 +96,50 @@ public final class TAFParser extends AbstractParser<TAF> {
 
         // Handle rest of second line.
         for (int j = i; j < line1parts.length; j++) {
-            if (line1parts[j].startsWith(PROB)) {
-                taf.setProbability(Integer.valueOf(line1parts[j].substring(4)));
-            } else if (RMK.equals(line1parts[j])) {
+            String part = line1parts[j];
+            if (RMK.equals(part)) {
                 parseRMK(taf, line1parts, j);
+            } else if (part.startsWith(TX)) {
+                taf.setMaxTemperature(parseTemperature(part));
+            } else if (part.startsWith(TN)) {
+                taf.setMinTemperature(parseTemperature(part));
             } else {
-                generalParse(taf, line1parts[j]);
+                generalParse(taf, part);
             }
         }
         // Process other lines.
         for (int j = 1; j < lines.length; j++) {
             // Split the line.
-            String[] parts = tokenize(lines[j]);
+            String[] parts = lines[j];
             processLines(taf, parts);
         }
         return taf;
+    }
+
+    /**
+     * Extracts all lines and tokenize them
+     * @param pTAFCode raw TAF which may already contains some linebreaks
+     * @return 2d jagged array containing lines and their tokens
+     */
+    private String[][] extractLineTokens(final String pTAFCode) {
+        String cleanedInput = pTAFCode
+                .replace("\n", " ")   // remove all linebreaks
+                .replaceAll("\\s{2,}", " ");  // remove unnecessary whitespaces
+
+        String[] lines = cleanedInput
+                .replaceAll("\\s(PROB\\d{2}\\sTEMPO|TEMPO|BECMG|FM|PROB)", "\n$1")
+                .split("\n");
+        String[][] lineTokens = Arrays.stream(lines).map(this::tokenize).toArray(String[][]::new);
+        if (lineTokens.length > 1) {
+            // often temperatures are set in the end of the TAF report
+            String[] last = lineTokens[lines.length - 1];
+            List<String> temperatures = Arrays.stream(last).filter(code -> code.startsWith(TX) || code.startsWith(TN)).collect(Collectors.toList());
+            if (!temperatures.isEmpty()) {
+                lineTokens[0] = Stream.concat(Arrays.stream(lineTokens[0]), temperatures.stream()).toArray(String[]::new);
+                lineTokens[lines.length - 1] = Arrays.stream(last).filter(code -> !code.startsWith(TX) && !code.startsWith(TN)).toArray(String[]::new);
+            }
+        }
+        return lineTokens;
     }
 
     /**
@@ -132,14 +165,24 @@ public final class TAFParser extends AbstractParser<TAF> {
             }
             pTaf.addFM(change);
         } else if (pParts[0].startsWith(PROB)) {
-            PROBTafTrend change = new PROBTafTrend();
-            iterChanges(0, pParts, change);
-            pTaf.addProb(change);
+            int probability = parseProbability(pParts[0]);
+            if (pParts.length > 1 && pParts[1].equals(TEMPO)) {
+                TEMPOTafTrend change = new TEMPOTafTrend();
+                iterChanges(2, pParts, change);
+                change.setProbability(probability);
+                pTaf.addTempo(change);
+            } else {
+                PROBTafTrend change = new PROBTafTrend();
+                change.setProbability(probability);
+                iterChanges(1, pParts, change);
+                pTaf.addProb(change);
+            }
         }
     }
 
     /**
      * Updates the change object according to the string.
+     *
      * @param change the change object to update.
      * @param pPart the string to parse.
      */
@@ -153,19 +196,22 @@ public final class TAFParser extends AbstractParser<TAF> {
 
     /**
      * Updates the change object according to the string.
+     *
      * @param pChange the change object to update.
      * @param pPart String containing the information.
      */
     protected void processGeneralChanges(final AbstractTafTrend<?> pChange, final String pPart) {
-        if (pPart.startsWith(PROB)) {
-            pChange.setProbability(Integer.parseInt(pPart.substring(4)));
-        } else if (pPart.startsWith("TX")) {
-            pChange.setMaxTemperature(parseTemperature(pPart));
-        } else if (pPart.startsWith("TN")) {
-            pChange.setMinTemperature(parseTemperature(pPart));
-        } else {
-            generalParse(pChange, pPart);
-        }
+        generalParse(pChange, pPart);
+    }
+
+    /**
+     * parses the probability out of PROB??
+     *
+     * @param pPart
+     * @return
+     */
+    protected int parseProbability(final String pPart) {
+        return Integer.parseInt(pPart.substring(4));
     }
 
     /**


### PR DESCRIPTION
@mivek Updated PR according to the naming mentioned in #160 and rebased to master to have a cleaner commit log. I also incorporated your other two remarks.

As discussed in #157, this PR makes parsing TAF more robust by not relying on line breaks.
Furthermore, it contains some correction in the model by allowing probabilities only on PROB and TEMPO trends. Besides that, temperatures are moved to main TAF, since they only exists once per report. Note that these min/max temperatures are often added to the end of a report, therefore some special handling for to move them in front for parsing was added.

