### PR TITLE
handle end indicator while tokenizing

### DIFF
--- a/src/main/java/io/github/mivek/parser/AbstractParser.java
+++ b/src/main/java/io/github/mivek/parser/AbstractParser.java
@@ -39,7 +39,7 @@ public abstract class AbstractParser<T extends AbstractWeatherCode> {
     /** Pattern for RMK. */
     protected static final String RMK = "RMK";
     /** Pattern regex to tokenize the code. */
-    private static final Pattern TOKENIZE_REGEX = Pattern.compile("(\\d \\d/\\dSM|\\S+)");
+    private static final Pattern TOKENIZE_REGEX = Pattern.compile("\\s((?=\\d/\\dSM)(?<!\\s\\d\\s)|(?!\\d/\\dSM))|=\\z");
     /** Pattern regex for the intensity of a phenomenon. */
     private static final Pattern INTENSITY_REGEX = Pattern.compile("^(-|\\+|VC)");
     /** Pattern for CAVOK. */
@@ -174,13 +174,7 @@ public abstract class AbstractParser<T extends AbstractWeatherCode> {
      * @return a array of tokens
      */
     protected String[] tokenize(final String pCode) {
-        List<String> tokens = new ArrayList<>();
-
-        Matcher m = TOKENIZE_REGEX.matcher(pCode);
-        while (m.find()) {
-            tokens.add(m.group(1));
-        }
-        return tokens.toArray(new String[0]);
+        return TOKENIZE_REGEX.split(pCode);
     }
 
     /**

--- a/src/main/java/io/github/mivek/parser/AbstractParser.java
+++ b/src/main/java/io/github/mivek/parser/AbstractParser.java
@@ -15,10 +15,7 @@ import io.github.mivek.model.WeatherCondition;
 import io.github.mivek.utils.Regex;
 
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**

--- a/src/test/java/io/github/mivek/parser/AbstractParserTest.java
+++ b/src/test/java/io/github/mivek/parser/AbstractParserTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractParserTest<T extends AbstractWeatherCode> {
     public void testTokenize() {
         // GIVEN a string with 1 1/2SM
         String code = "METAR KTTN 051853Z 04011KT 1 1/2SM VCTS SN FZFG BKN003 OVC010 M02/M02 A3006 RMK AO2 TSB40 SLP176 P0002 T10171017=";
-        String[] tokens = { "METAR", "KTTN", "051853Z", "04011KT", "1 1/2SM", "VCTS", "SN", "FZFG", "BKN003", "OVC010", "M02/M02", "A3006", "RMK", "AO2", "TSB40", "SLP176", "P0002", "T10171017=" };
+        String[] tokens = { "METAR", "KTTN", "051853Z", "04011KT", "1 1/2SM", "VCTS", "SN", "FZFG", "BKN003", "OVC010", "M02/M02", "A3006", "RMK", "AO2", "TSB40", "SLP176", "P0002", "T10171017" };
         // WHEN tokenizing the string
         String[] result = getSut().tokenize(code);
         // THEN the visibility part is 1 1/2SM


### PR DESCRIPTION
Fix for #168 which splits on every whitespace (except when between digits with SM) and on the end indicator (=). 