### PR TITLE
:bug: Missing wind Unit of measure lead to NPE #196

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.mivek</groupId>
     <artifactId>metarParser</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
     <name>metarParser</name>
     <description>This project is a metar parser.
         Use the MetarFacade and its method "parse()" to parse a metar string and retrieve a Metar Object.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.mivek</groupId>
     <artifactId>metarParser</artifactId>
-    <version>1.10.1</version>
+    <version>1.10.0</version>
     <name>metarParser</name>
     <description>This project is a metar parser.
         Use the MetarFacade and its method "parse()" to parse a metar string and retrieve a Metar Object.

--- a/src/main/java/io/github/mivek/command/common/BaseWindCommand.java
+++ b/src/main/java/io/github/mivek/command/common/BaseWindCommand.java
@@ -28,6 +28,10 @@ public interface BaseWindCommand extends Command {
         if (pGust != null) {
             pWind.setGust(Integer.parseInt(pGust));
         }
-        pWind.setUnit(pUnit);
+        if (pUnit == null) {
+            pWind.setUnit("KT");
+        } else {
+            pWind.setUnit(pUnit);
+        }
     }
 }

--- a/src/main/java/io/github/mivek/command/common/WindCommand.java
+++ b/src/main/java/io/github/mivek/command/common/WindCommand.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
  */
 public final class WindCommand implements BaseWindCommand {
     /** Pattern regex for wind. */
-    private static final Pattern WIND_REGEX = Pattern.compile("(\\w{3})(\\d{2})G?(\\d{2})?(KT|MPS|KM\\/H)");
+    private static final Pattern WIND_REGEX = Pattern.compile("(VRB|\\d{3})(\\d{2})G?(\\d{2})?(KT|MPS|KM\\/H)?");
     /**
      * This method parses the wind part of the metar code. It parses the generic
      * part.

--- a/src/test/java/io/github/mivek/parser/MetarParserTest.java
+++ b/src/test/java/io/github/mivek/parser/MetarParserTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.*;
 
 /**
  * Test class for {@link MetarParser}
- * @author mivek
  *
+ * @author mivek
  */
 public class MetarParserTest extends AbstractParserTest<Metar> {
 
@@ -338,12 +338,28 @@ public class MetarParserTest extends AbstractParserTest<Metar> {
         assertThat(m.getRemark(), containsString("SF5NS3 " + Messages.getInstance().getString("Remark.Sea.Level.Pressure", "1013.4")));
     }
 
-    @Test public void testParseRMK() {
+    @Test
+    public void testParseRMK() {
         Metar m = new Metar();
-        String[] array = { "RMK", "AO2", "TSB40", "SLP176", "P0002", "T10171017=" };
+        String[] array = {"RMK", "AO2", "TSB40", "SLP176", "P0002", "T10171017="};
         getSut().parseRMK(m, array, 0);
         String rmk = m.getRemark();
         assertNotNull(rmk);
         assertThat(rmk, not(containsString("RMK")));
     }
+
+    @Test
+    public void alternativeWindForm() {
+        String code = "ENLK 081350Z 26026G40 240V300 9999 VCSH FEW025 BKN030 02/M01 Q0996";
+        Metar m = fSut.parse(code);
+        assertNotNull(m);
+        assertNotNull(m.getWind());
+        assertEquals(Integer.valueOf(260), m.getWind().getDirectionDegrees());
+        assertEquals(26, m.getWind().getSpeed());
+        assertEquals(40, m.getWind().getGust());
+        assertEquals("KT", m.getWind().getUnit());
+        assertEquals(240, m.getWind().getExtreme1());
+        assertEquals(300, m.getWind().getExtreme2());
+    }
+
 }


### PR DESCRIPTION
Fix for Issue #196 .

Use KT as fallback of unit of measure for wind.