### PR TITLE
Bugfix/enum to string When changing the local the enumerations translations are not updated

### DIFF
--- a/metarParser-commons/src/main/resources/internationalization/messages.properties
+++ b/metarParser-commons/src/main/resources/internationalization/messages.properties
@@ -121,6 +121,7 @@ WeatherChangeType.TEMPO=Temporary
 WeatherChangeType.PROB=Probability
 
 TimeIndicator.AT=at
+TimeIndicator.FM=From
 TimeIndicator.TL=until
 ToString.airport=airport
 ToString.altimeter=altimeter (hPa)

--- a/metarParser-commons/src/main/resources/internationalization/messages_ pl_PL.properties
+++ b/metarParser-commons/src/main/resources/internationalization/messages_ pl_PL.properties
@@ -81,4 +81,5 @@ WeatherChangeType.BECMG = Nadchodząca
 WeatherChangeType.TEMPO = Tymczasowa
 WeatherChangeType.PROB = Prawdopodobieństwo
 TimeIndicator.AT = o
+TimeIndicator.FM = od
 TimeIndicator.TL = do

--- a/metarParser-commons/src/main/resources/internationalization/messages_de.properties
+++ b/metarParser-commons/src/main/resources/internationalization/messages_de.properties
@@ -69,6 +69,7 @@ WeatherChangeType.BECMG = \00DCbergehend
 WeatherChangeType.TEMPO = Tempor\00E4r
 WeatherChangeType.PROB = Warscheinlichkeit
 TimeIndicator.AT = um
+TimeIndicator.FM = Von
 TimeIndicator.TL = bis um
 Phenomenon.TS = Gewittersturm
 Remark.AO1 = automatisierte Station ohne Niederschlagsunterscheidung

--- a/metarParser-commons/src/main/resources/internationalization/messages_fr.properties
+++ b/metarParser-commons/src/main/resources/internationalization/messages_fr.properties
@@ -113,12 +113,12 @@ Converter.U=accroissement
 Converter.VRB=Variable
 Converter.W=Ouest
 WeatherChangeType.FM=De
-WeatherChangeType.BECMG=Becoming
-WeatherChangeType.TEMPO=Temporary
+WeatherChangeType.BECMG=Devenant
+WeatherChangeType.TEMPO=Temporairement
 WeatherChangeType.PROB=Probabilit\u00e9
 
 TimeIndicator.AT=\u00e0
-
+TimeIndicator.FM=De
 TimeIndicator.TL=jusqu'\u00e0
 ToString.airport=a\u00e9roport
 ToString.altimeter=altim\u00e8tre (hPa)

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/CloudQuantity.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/CloudQuantity.java
@@ -11,46 +11,21 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum CloudQuantity {
     /** Sky clear. */
-    SKC("SKC", Messages.getInstance().getString("CloudQuantity.SKC")), //$NON-NLS-1$
+    SKC, //$NON-NLS-1$
     /** Few clouds. */
-    FEW("FEW", Messages.getInstance().getString("CloudQuantity.FEW")), //$NON-NLS-1$
+    FEW, //$NON-NLS-1$
     /** Broken ceiling. */
-    BKN("BKN", Messages.getInstance().getString("CloudQuantity.BKN")), //$NON-NLS-1$
+    BKN, //$NON-NLS-1$
     /** Scattered. */
-    SCT("SCT", Messages.getInstance().getString("CloudQuantity.SCT")), //$NON-NLS-1$
+    SCT, //$NON-NLS-1$
     /** Overcast. */
-    OVC("OVC", Messages.getInstance().getString("CloudQuantity.OVC")), //$NON-NLS-1$
+    OVC, //$NON-NLS-1$
     /** No significant cloud. */
-    NSC("NSC", Messages.getInstance().getString("CloudQuantity.NSC")); //$NON-NLS-1$
+    NSC; //$NON-NLS-1$
 
-    /** Shortcut of the cloud quanity. */
-    private final String shortcut; //$NON-NLS-1$
-    /** The name of the quantity. */
-    private final String name; //$NON-NLS-1$
-
-    /**
-     * Constructor.
-     *
-     * @param shortcut a string representing the shortcut.
-     * @param name     The meaning of the shortcut.
-     */
-    CloudQuantity(final String shortcut, final String name) {
-        this.shortcut = shortcut;
-        this.name = name;
-    }
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("CloudQuantity." + name());
     }
-
-    /**
-     * Returns the shortcut.
-     *
-     * @return a string.
-     */
-    public String getShortcut() {
-        return shortcut;
-    }
-
 }

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/CloudType.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/CloudType.java
@@ -10,55 +10,32 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum CloudType {
     /** cumulonimbus. */
-    CB("CB", Messages.getInstance().getString("CloudType.CB")), //$NON-NLS-1$
+    CB, //$NON-NLS-1$
     /** towering cumulus, cumulus congestus. */
-    TCU("TCU", Messages.getInstance().getString("CloudType.TCU")), //$NON-NLS-1$
+    TCU, //$NON-NLS-1$
     /** Cirrus. */
-    CI("CI", Messages.getInstance().getString("CloudType.CI")),
+    CI,
     /** Cirrocumulus. */
-    CC("CC", Messages.getInstance().getString("CloudType.CC")),
+    CC,
     /** Cirrostratus. */
-    CS("CS", Messages.getInstance().getString("CloudType.CS")),
+    CS,
     /** Altocumulus. */
-    AC("AC", Messages.getInstance().getString("CloudType.AC")),
+    AC,
     /** Stratus. */
-    ST("ST", Messages.getInstance().getString("CloudType.ST")),
+    ST,
     /** Cumulus. */
-    CU("CU", Messages.getInstance().getString("CloudType.CU")),
+    CU,
     /** Astrostratus. */
-    AS("AS", Messages.getInstance().getString("CloudType.AS")),
+    AS,
     /** Nimbostratus. */
-    NS("NS", Messages.getInstance().getString("CloudType.NS")),
+    NS,
     /** Stratocumulus. */
-    SC("SC", Messages.getInstance().getString("CloudType.SC"));
-
-    /** The shortcut of the cloud type. */
-    private final String shortcut; //$NON-NLS-1$
-    /** The name of the cloud type. */
-    private final String name; //$NON-NLS-1$
-
-    /**
-     * Constructor.
-     *
-     * @param shortcut string for shortcut.
-     * @param name     string for name.
-     */
-    CloudType(final String shortcut, final String name) {
-        this.shortcut = shortcut;
-        this.name = name;
-    }
+    SC;
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("CloudType." + name());
     }
 
-    /**
-     * returns the shortcut of the type.
-     *
-     * @return string shortcut.
-     */
-    public String getShortcut() {
-        return shortcut;
-    }
+
 }

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/Descriptive.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/Descriptive.java
@@ -10,49 +10,42 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum Descriptive {
     /** Showers. */
-    SHOWERS("SH", Messages.getInstance().getString("Descriptive.SH")), //$NON-NLS-1$
+    SHOWERS("SH"), //$NON-NLS-1$
     /** Shallow. */
-    SHALLOW("MI", Messages.getInstance().getString("Descriptive.MI")), //$NON-NLS-1$
+    SHALLOW("MI"), //$NON-NLS-1$
     /** Patches. */
-    PATCHES("BC", Messages.getInstance().getString("Descriptive.BC")), //$NON-NLS-1$
+    PATCHES("BC"), //$NON-NLS-1$
     /** Partial. */
-    PARTIAL("PR", Messages.getInstance().getString("Descriptive.PR")), //$NON-NLS-1$
+    PARTIAL("PR"), //$NON-NLS-1$
     /** Low drifting. */
-    DRIFTING("DR", Messages.getInstance().getString("Descriptive.DR")), //$NON-NLS-1$
+    DRIFTING("DR"), //$NON-NLS-1$
     /** Thunderstorm. */
-    THUNDERSTORM("TS", Messages.getInstance().getString("Descriptive.TS")), //$NON-NLS-1$
+    THUNDERSTORM("TS"), //$NON-NLS-1$
     /** blowing. */
-    BLOWING("BL", Messages.getInstance().getString("Descriptive.BC")), //$NON-NLS-1$
+    BLOWING("BL"), //$NON-NLS-1$
     /** Freezing. */
-    FREEZING("FZ", Messages.getInstance().getString("Descriptive.FZ")); //$NON-NLS-1$
+    FREEZING("FZ"); //$NON-NLS-1$
 
-    /** Shortcut of the descriptive. */
-    private final String shortcut; //$NON-NLS-1$
-    /** Meaning of the descriptive. */
-    private final String name; //$NON-NLS-1$
+    /** The descriptive's shortcut. */
+    private final String shortcut;
 
     /**
-     * Connstructor.
-     *
-     * @param shortcut A string for the shorcut.
-     * @param name     a string for the meaning.
+     * Constructor.
+     * @param shortcut the shortcut of the descriptive.
      */
-    Descriptive(final String shortcut, final String name) {
+    Descriptive(final String shortcut) {
         this.shortcut = shortcut;
-        this.name = name;
+    }
+
+    /**
+     * @return The shortcut.
+     */
+    public String getShortcut() {
+        return this.shortcut;
     }
 
     @Override
     public String toString() {
-        return name;
-    }
-
-    /**
-     * return shortcut.
-     *
-     * @return string.
-     */
-    public String getShortcut() {
-        return shortcut;
+        return Messages.getInstance().getString("Descriptive." + shortcut);
     }
 }

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/Intensity.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/Intensity.java
@@ -11,31 +11,27 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum Intensity {
     /** Light intensity. */
-    LIGHT("-", Messages.getInstance().getString("Intensity.-")), //$NON-NLS-1$
+    LIGHT("-"), //$NON-NLS-1$
     /** Heavy intensity. */
-    HEAVY("+", Messages.getInstance().getString("Intensity.+")), //$NON-NLS-1$
+    HEAVY("+"), //$NON-NLS-1$
     /** In vicinity. */
-    IN_VICINITY("VC", Messages.getInstance().getString("Intensity.VC")); //$NON-NLS-1$
+    IN_VICINITY("VC"); //$NON-NLS-1$
 
     /** The shortcut of the intensity. */
     private final String shortcut; //$NON-NLS-1$
-    /** The meaning of the intensity. */
-    private final String name; //$NON-NLS-1$
 
     /**
      * Constructor.
      *
      * @param shortcut A String for the shortcut.
-     * @param name     A string for the meaning.
      */
-    Intensity(final String shortcut, final String name) {
+    Intensity(final String shortcut) {
         this.shortcut = shortcut;
-        this.name = name;
     }
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("Intensity." + getShortcut());
     }
 
     /**

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/Phenomenon.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/Phenomenon.java
@@ -11,69 +11,65 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum Phenomenon {
     /** Rain. */
-    RAIN("RA", Messages.getInstance().getString("Phenomenon.RA")), //$NON-NLS-1$
+    RAIN("RA"), //$NON-NLS-1$
     /** Drizzle. */
-    DRIZZLE("DZ", Messages.getInstance().getString("Phenomenon.DZ")), //$NON-NLS-1$
+    DRIZZLE("DZ"), //$NON-NLS-1$
     /** Snow. */
-    SNOW("SN", Messages.getInstance().getString("Phenomenon.SN")), //$NON-NLS-1$
+    SNOW("SN"), //$NON-NLS-1$
     /** Snow grains. */
-    SNOW_GRAINS("SG", Messages.getInstance().getString("Phenomenon.SG")), //$NON-NLS-1$
+    SNOW_GRAINS("SG"), //$NON-NLS-1$
     /** Ice pellets. */
-    ICE_PELLETS("PL", Messages.getInstance().getString("Phenomenon.PL")), //$NON-NLS-1$
+    ICE_PELLETS("PL"), //$NON-NLS-1$
     /** Ice crystals. */
-    ICE_CRYSTALS("IC", Messages.getInstance().getString("Phenomenon.IC")), //$NON-NLS-1$
+    ICE_CRYSTALS("IC"), //$NON-NLS-1$
     /** Hail. */
-    HAIL("GR", Messages.getInstance().getString("Phenomenon.GR")), //$NON-NLS-1$
+    HAIL("GR"), //$NON-NLS-1$
     /** Small hail. */
-    SMALL_HAIL("GS", Messages.getInstance().getString("Phenomenon.GS")), //$NON-NLS-1$
+    SMALL_HAIL("GS"), //$NON-NLS-1$
     /** Unknow precipitation. */
-    UNKNOW_PRECIPITATION("UP", Messages.getInstance().getString("Phenomenon.UP")), //$NON-NLS-1$
+    UNKNOW_PRECIPITATION("UP"), //$NON-NLS-1$
     /** Fog. */
-    FOG("FG", Messages.getInstance().getString("Phenomenon.FG")), //$NON-NLS-1$
+    FOG("FG"), //$NON-NLS-1$
     /** Volcanic ashes. */
-    VOLCANIC_ASH("VA", Messages.getInstance().getString("Phenomenon.VA")), //$NON-NLS-1$
+    VOLCANIC_ASH("VA"), //$NON-NLS-1$
     /** Mist. */
-    MIST("BR", Messages.getInstance().getString("Phenomenon.BR")), //$NON-NLS-1$
+    MIST("BR"), //$NON-NLS-1$
     /** Haze. */
-    HAZE("HZ", Messages.getInstance().getString("Phenomenon.HZ")), //$NON-NLS-1$
+    HAZE("HZ"), //$NON-NLS-1$
     /** Widespread dust. */
-    WIDESPREAD_DUST("DU", Messages.getInstance().getString("Phenomenon.DU")), //$NON-NLS-1$
+    WIDESPREAD_DUST("DU"), //$NON-NLS-1$
     /** Smoke. */
-    SMOKE("FU", Messages.getInstance().getString("Phenomenon.FU")), //$NON-NLS-1$
+    SMOKE("FU"), //$NON-NLS-1$
     /** Sand. */
-    SAND("SA", Messages.getInstance().getString("Phenomenon.SA")), //$NON-NLS-1$
+    SAND("SA"), //$NON-NLS-1$
     /** Spray. */
-    SPRAY("PY", Messages.getInstance().getString("Phenomenon.PY")), //$NON-NLS-1$
+    SPRAY("PY"), //$NON-NLS-1$
     /** Squall. */
-    SQUALL("SQ", Messages.getInstance().getString("Phenomenon.SQ")), //$NON-NLS-1$
+    SQUALL("SQ"), //$NON-NLS-1$
     /** Sand whirl. */
-    SAND_WHIRLS("PO", Messages.getInstance().getString("Phenomenon.PO")), //$NON-NLS-1$
+    SAND_WHIRLS("PO"), //$NON-NLS-1$
     /** Duststorm. */
-    DUSTSTORM("DS", Messages.getInstance().getString("Phenomenon.DS")), //$NON-NLS-1$
+    DUSTSTORM("DS"), //$NON-NLS-1$
     /** Sandstorm. */
-    SANDSTORM("SS", Messages.getInstance().getString("Phenomenon.SS")), //$NON-NLS-1$
+    SANDSTORM("SS"), //$NON-NLS-1$
     /** Funnel cloud. */
-    FUNNEL_CLOUD("FC", Messages.getInstance().getString("Phenomenon.FC")); //$NON-NLS-1$
+    FUNNEL_CLOUD("FC"); //$NON-NLS-1$
 
     /** Shortcut of the phenomenon. */
     private final String shortcut;
-    /** Name of the phenomenon. */
-    private final String name;
 
     /**
      * Constructor.
      *
      * @param shortcut string for the shortcut.
-     * @param name     string for the name.
      */
-    Phenomenon(final String shortcut, final String name) {
+    Phenomenon(final String shortcut) {
         this.shortcut = shortcut;
-        this.name = name;
     }
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("Phenomenon." + getShortcut());
     }
 
     /**

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/TimeIndicator.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/TimeIndicator.java
@@ -9,41 +9,35 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum TimeIndicator {
     /** The AT value of the metar trend. */
-    AT("AT", Messages.getInstance().getString("TimeIndicator.AT")),
+    AT("AT"),
     /** The FM value of the metar trend. */
-    FM("FM", Messages.getInstance().getString("WeatherChangeType.FM")),
+    FM("FM"),
     /** The TL value of the metar trend. */
-    TL("TL", Messages.getInstance().getString("TimeIndicator.TL"));
+    TL("TL");
 
     /**
      * Shortcut of the time indicator.
      */
-    private final String shortCut;
-    /**
-     * Name of the time indicator.
-     */
-    private final String name;
+    private final String shortcut;
 
     /**
      * Constructor.
      *
-     * @param shortCut the shortcut of the indicator.
-     * @param name     the name of the indicator.
+     * @param shortcut the shortcut of the indicator.
      */
-    TimeIndicator(final String shortCut, final String name) {
-        this.shortCut = shortCut;
-        this.name = name;
+    TimeIndicator(final String shortcut) {
+        this.shortcut = shortcut;
     }
 
     /**
      * @return the shortcut.
      */
     public String getShortcut() {
-        return shortCut;
+        return shortcut;
     }
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("TimeIndicator." + getShortcut());
     }
 }

--- a/metarParser-entities/src/main/java/io/github/mivek/enums/WeatherChangeType.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/enums/WeatherChangeType.java
@@ -7,39 +7,18 @@ import io.github.mivek.internationalization.Messages;
  */
 public enum WeatherChangeType {
     /** From enumeration. */
-    FM("FM", Messages.getInstance().getString("WeatherChangeType.FM")),
+    FM,
     /** Becoming enumeration. */
-    BECMG("BECMG", Messages.getInstance().getString("WeatherChangeType.BECMG")),
+    BECMG,
     /** Tempo enumeration. */
-    TEMPO("TEMPO", Messages.getInstance().getString("WeatherChangeType.TEMPO")),
+    TEMPO,
     /** Probability change. */
-    PROB("PROB", Messages.getInstance().getString("WeatherChangeType.PROB"));
-    /** Shortcut attribute. */
-    private final String shortcut;
-    /** Name of the enumeration. */
-    private final String name;
+    PROB;
 
-    /**
-     * Constructor.
-     *
-     * @param shortcut the shortcut of the enumeration
-     * @param name     the name of the enumeration
-     */
-    WeatherChangeType(final String shortcut, final String name) {
-        this.shortcut = shortcut;
-        this.name = name;
-    }
-
-    /**
-     * @return the shortcut.
-     */
-    public String getShortcut() {
-        return shortcut;
-    }
 
     @Override
     public String toString() {
-        return name;
+        return Messages.getInstance().getString("WeatherChangeType." + name());
     }
 
 }

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/CloudQuantityTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/CloudQuantityTest.java
@@ -1,0 +1,23 @@
+package io.github.mivek.enums;
+
+import io.github.mivek.internationalization.Messages;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author mivek
+ */
+public class CloudQuantityTest {
+
+    @Test
+    public void testToStringMultipleLocale() {
+        Messages.getInstance().setLocale(Locale.FRANCE);
+        assertEquals("peu", CloudQuantity.FEW.toString());
+
+        Messages.getInstance().setLocale(Locale.ENGLISH);
+        assertEquals("few", CloudQuantity.FEW.toString());
+    }
+}

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/CloudTypeTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/CloudTypeTest.java
@@ -5,21 +5,19 @@ import org.junit.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-public class IntensityTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetEnum() {
-        Intensity.getEnum("QWERTY");
-    }
+/**
+ * @author mivek
+ */
+public class CloudTypeTest {
 
     @Test
     public void testToStringWithMultipleLocale() {
         Messages.getInstance().setLocale(Locale.FRANCE);
-        assertEquals("Faible", Intensity.LIGHT.toString());
+        assertEquals("Cirrocumulus", CloudType.CC.toString());
 
         Messages.getInstance().setLocale(Locale.ENGLISH);
-        assertEquals("Light", Intensity.LIGHT.toString());
+        assertEquals("CirroCumulus", CloudType.CC.toString());
     }
 }

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/DescriptiveTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/DescriptiveTest.java
@@ -7,19 +7,17 @@ import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
-public class IntensityTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetEnum() {
-        Intensity.getEnum("QWERTY");
-    }
+/**
+ * @author mivek
+ */
+public class DescriptiveTest {
 
     @Test
     public void testToStringWithMultipleLocale() {
         Messages.getInstance().setLocale(Locale.FRANCE);
-        assertEquals("Faible", Intensity.LIGHT.toString());
+        assertEquals("averses de", Descriptive.SHOWERS.toString());
 
         Messages.getInstance().setLocale(Locale.ENGLISH);
-        assertEquals("Light", Intensity.LIGHT.toString());
+        assertEquals("showers of", Descriptive.SHOWERS.toString());
     }
 }

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/PhenomenonTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/PhenomenonTest.java
@@ -5,21 +5,19 @@ import org.junit.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-public class IntensityTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetEnum() {
-        Intensity.getEnum("QWERTY");
-    }
+/**
+ * @author mivek
+ */
+public class PhenomenonTest {
 
     @Test
     public void testToStringWithMultipleLocale() {
         Messages.getInstance().setLocale(Locale.FRANCE);
-        assertEquals("Faible", Intensity.LIGHT.toString());
+        assertEquals("pluie", Phenomenon.RAIN.toString());
 
         Messages.getInstance().setLocale(Locale.ENGLISH);
-        assertEquals("Light", Intensity.LIGHT.toString());
+        assertEquals("rain", Phenomenon.RAIN.toString());
     }
 }

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/TimeIndicatorTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/TimeIndicatorTest.java
@@ -5,21 +5,19 @@ import org.junit.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-public class IntensityTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetEnum() {
-        Intensity.getEnum("QWERTY");
-    }
+/**
+ * @author mivek
+ */
+public class TimeIndicatorTest {
 
     @Test
     public void testToStringWithMultipleLocale() {
         Messages.getInstance().setLocale(Locale.FRANCE);
-        assertEquals("Faible", Intensity.LIGHT.toString());
+        assertEquals("De", TimeIndicator.FM.toString());
 
         Messages.getInstance().setLocale(Locale.ENGLISH);
-        assertEquals("Light", Intensity.LIGHT.toString());
+        assertEquals("From", TimeIndicator.FM.toString());
     }
 }

--- a/metarParser-entities/src/test/java/io/github/mivek/enums/WeatherChangeTypeTest.java
+++ b/metarParser-entities/src/test/java/io/github/mivek/enums/WeatherChangeTypeTest.java
@@ -5,21 +5,19 @@ import org.junit.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-public class IntensityTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetEnum() {
-        Intensity.getEnum("QWERTY");
-    }
+/**
+ * @author mivek
+ */
+public class WeatherChangeTypeTest {
 
     @Test
     public void testToStringWithMultipleLocale() {
         Messages.getInstance().setLocale(Locale.FRANCE);
-        assertEquals("Faible", Intensity.LIGHT.toString());
+        assertEquals("Devenant", WeatherChangeType.BECMG.toString());
 
         Messages.getInstance().setLocale(Locale.ENGLISH);
-        assertEquals("Light", Intensity.LIGHT.toString());
+        assertEquals("Becoming", WeatherChangeType.BECMG.toString());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
         <jacoco.coverage.branch.minimum>0.96</jacoco.coverage.branch.minimum>
         <jacoco.coverage.complexity.minimum>0.97</jacoco.coverage.complexity.minimum>
         <archunit-junit4.version>0.13.1</archunit-junit4.version>
+        <maven-project-info-reports-plugin.version>3.1.0</maven-project-info-reports-plugin.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     </properties>
 
     <developers>
@@ -123,6 +125,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${maven-site-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven-project-info-reports-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Bug: 

The enumerations were initialized with translation messages. So when changing the language with the `Messages.class`, the translation of the enum was not updated.

I removed the translation from the enumeration constructor and added a `toString` method to do the translation