### PR TITLE
Update data URLs as recommend by ourairports

### DIFF
--- a/metarParser-spi/src/main/java/io/github/mivek/provider/airport/impl/OurAirportsAirportProvider.java
+++ b/metarParser-spi/src/main/java/io/github/mivek/provider/airport/impl/OurAirportsAirportProvider.java
@@ -31,9 +31,9 @@ import java.util.Map;
  */
 public final class OurAirportsAirportProvider implements AirportProvider {
     /** URI to retrieve the list of countries. */
-    private static final String COUNTRIES_URI = "https://ourairports.com/data/countries.csv";
+    private static final String COUNTRIES_URI = "https://davidmegginson.github.io/ourairports-data/countries.csv";
     /** URI to retrieve the list of airports. */
-    private static final String AIRPORT_URI = "https://ourairports.com/data/airports.csv";
+    private static final String AIRPORT_URI = "https://davidmegginson.github.io/ourairports-data/airports.csv";
     /** Map of countries. */
     private final Map<String, Country> countries;
     /** Map of airports. */


### PR DESCRIPTION
Closes #407 

This is a simple URL update to guard against the app breaking if the current redirects are disabled.

I would love to get credit for this PR for `Hacktoberfest`.  The easiest way to do this would be to add a repo-level topic of `Hacktoberfest`.  