### PR TITLE
Update cloud regex not to match weathercondition

### DIFF
--- a/metarParser-parsers/src/main/java/io/github/mivek/command/common/CloudCommand.java
+++ b/metarParser-parsers/src/main/java/io/github/mivek/command/common/CloudCommand.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  */
 public final class CloudCommand implements Command {
     /** Pattern to recognize clouds. */
-    private static final Pattern CLOUD_REGEX = Pattern.compile("^(\\p{Upper}{3})(\\d{3}|/{3})?(\\p{Upper}{2,3}|/{3})?$");
+    private static final Pattern CLOUD_REGEX = Pattern.compile("^(\\p{Upper}{3})((\\d{3}|/{3})(\\p{Upper}{2,3}|/{3})?)?$");
     /** String to identify the unknown part in a cloud. */
     private static final String UNDEFINED = "///";
     /**
@@ -40,11 +40,11 @@ public final class CloudCommand implements Command {
         try {
             CloudQuantity cq = CloudQuantity.valueOf(cloudPart[1]);
             cloud.setQuantity(cq);
-            if (cloudPart[2] != null && !UNDEFINED.equals(cloudPart[2])) {
-                cloud.setHeight(100 * Integer.parseInt(cloudPart[2]));
-            }
             if (cloudPart[3] != null && !UNDEFINED.equals(cloudPart[3])) {
-                CloudType ct = CloudType.valueOf(cloudPart[3]);
+                cloud.setHeight(100 * Integer.parseInt(cloudPart[3]));
+            }
+            if (cloudPart[4] != null && !UNDEFINED.equals(cloudPart[4])) {
+                CloudType ct = CloudType.valueOf(cloudPart[4]);
                 cloud.setType(ct);
             }
             return cloud;

--- a/metarParser-parsers/src/test/java/io/github/mivek/parser/MetarParserTest.java
+++ b/metarParser-parsers/src/test/java/io/github/mivek/parser/MetarParserTest.java
@@ -420,4 +420,20 @@ class MetarParserTest extends AbstractWeatherCodeParserTest<Metar> {
         assertEquals("EKVG", m.getStation());
         assertThat(m.getClouds(), hasSize(2));
     }
+    @Test
+    void testParseVC() {
+        String code = "CYVM 282100Z 36028G36KT 1SM -SN DRSN VCBLSN OVC008 M03/M04 A2935 RMK SN2ST8 LAST STFFD OBS/NXT 291200UTC SLP940";
+
+        Metar m = parser.parse(code);
+
+        assertNotNull(m);
+        assertThat(m.getWeatherConditions(), hasSize(3));
+        assertEquals(Intensity.LIGHT, m.getWeatherConditions().get(0).getIntensity());
+        assertEquals(Phenomenon.SNOW, m.getWeatherConditions().get(0).getPhenomenons().get(0));
+        assertEquals(Descriptive.DRIFTING, m.getWeatherConditions().get(1).getDescriptive());
+        assertEquals(Phenomenon.SNOW, m.getWeatherConditions().get(1).getPhenomenons().get(0));
+        assertEquals(Intensity.IN_VICINITY, m.getWeatherConditions().get(2).getIntensity());
+        assertEquals(Descriptive.BLOWING, m.getWeatherConditions().get(2).getDescriptive());
+        assertEquals(Phenomenon.SNOW, m.getWeatherConditions().get(2).getPhenomenons().get(0));
+    }
 }


### PR DESCRIPTION
Replaced the cloud regex, to only match the cloud type only if the cloud layer's height is present. This should prevent tokens made of 6 letters to match the cloud regex.

This fixes #432 