### PR TITLE
Handle case when airport is not found when retrieving METAR or TAF

### DIFF
--- a/.github/workflows/build_sonar_verify.yml
+++ b/.github/workflows/build_sonar_verify.yml
@@ -54,13 +54,13 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/sonar-master.yml
+++ b/.github/workflows/sonar-master.yml
@@ -18,13 +18,13 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/metarParser-services/src/main/java/io/github/mivek/service/MetarService.java
+++ b/metarParser-services/src/main/java/io/github/mivek/service/MetarService.java
@@ -6,8 +6,6 @@ import io.github.mivek.parser.MetarParser;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,14 +35,7 @@ public final class MetarService extends AbstractWeatherCodeService<Metar> {
 
     @Override
     public Metar retrieveFromAirport(final String icao) throws ParseException, IOException, URISyntaxException, InterruptedException {
-        checkIcao(icao);
-        String website = NOAA_METAR_URL + icao.toUpperCase()
-                + ".TXT";
-        HttpRequest request = buildRequest(website);
-
-        HttpResponse<Stream<String>> response = HttpClient.newBuilder()
-                .build()
-                .send(request, HttpResponse.BodyHandlers.ofLines());
+        HttpResponse<Stream<String>> response = getResponse(icao, NOAA_METAR_URL);
         return getParser().parse(response.body().skip(1).collect(Collectors.joining()));
     }
 

--- a/metarParser-services/src/main/java/io/github/mivek/service/TAFService.java
+++ b/metarParser-services/src/main/java/io/github/mivek/service/TAFService.java
@@ -7,8 +7,6 @@ import io.github.mivek.parser.TAFParser;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,14 +38,7 @@ public final class TAFService extends AbstractWeatherCodeService<TAF> {
 
     @Override
     public TAF retrieveFromAirport(final String icao) throws IOException, ParseException, URISyntaxException, InterruptedException {
-        checkIcao(icao);
-        String website = NOAA_TAF_URL + icao.toUpperCase()
-                + ".TXT";
-        HttpRequest request = buildRequest(website);
-
-        HttpResponse<Stream<String>> response = HttpClient.newBuilder()
-                .build()
-                .send(request, HttpResponse.BodyHandlers.ofLines());
+        HttpResponse<Stream<String>> response = getResponse(icao, NOAA_TAF_URL);
         StringBuilder sb = new StringBuilder();
         // Throw the first line since it is not part of the TAF event.
         response.body().skip(1).forEach(currentLine -> sb.append(currentLine.replaceAll("\\s{2,}", "")).append("\n"));

--- a/metarParser-services/src/test/java/io/github/mivek/service/AbstractWeatherCodeServiceTest.java
+++ b/metarParser-services/src/test/java/io/github/mivek/service/AbstractWeatherCodeServiceTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 abstract class AbstractWeatherCodeServiceTest<T extends AbstractWeatherCode> {
     protected abstract AbstractWeatherCodeService<T> getService();
 
@@ -32,4 +31,9 @@ abstract class AbstractWeatherCodeServiceTest<T extends AbstractWeatherCode> {
         assertThat(res.getAirport().getIcao(), is("LFPG"));
     }
 
+    @Test
+    void testRetrieveFromAirportNotFound() {
+        ParseException e = assertThrows(ParseException.class, () -> getService().retrieveFromAirport("lftm"));
+        assertEquals(ErrorCodes.ERROR_CODE_INVALID_ICAO, e.getErrorCode());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
         <jacoco.coverage.branch.minimum>0.96</jacoco.coverage.branch.minimum>
         <jacoco.coverage.complexity.minimum>0.97</jacoco.coverage.complexity.minimum>
         <archunit-junit5.version>1.2.1</archunit-junit5.version>
-        <checkstyle.version>10.12.7</checkstyle.version>
+        <checkstyle.version>10.13.0</checkstyle.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <hamcrest.version>2.2</hamcrest.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <junit.version>5.10.1</junit.version>
+        <junit.version>5.10.2</junit.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <maven.gpg.plugin.version>3.1.0</maven.gpg.plugin.version>
@@ -67,9 +67,9 @@
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <commons-csv.version>1.10.0</commons-csv.version>
         <pitest-junit5-plugin.version>1.2.1</pitest-junit5-plugin.version>
-        <pitest-maven.version>1.15.3</pitest-maven.version>
-        <slf4j-nop.version>2.0.11</slf4j-nop.version>
-        <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+        <pitest-maven.version>1.15.8</pitest-maven.version>
+        <slf4j-nop.version>2.0.12</slf4j-nop.version>
+        <spotbugs-maven-plugin.version>4.8.3.1</spotbugs-maven-plugin.version>
         <sonar.organization>mivek-github</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>


### PR DESCRIPTION
Refactor code `getResponse` in parent class.

This fixes #576, alternative to #577 