### PR TITLE
feat: parse TAF messages without delivery time

### DIFF
--- a/metarParser-parsers/src/main/java/io/github/mivek/parser/AbstractWeatherCodeParser.java
+++ b/metarParser-parsers/src/main/java/io/github/mivek/parser/AbstractWeatherCodeParser.java
@@ -42,16 +42,26 @@ public abstract class AbstractWeatherCodeParser<T extends AbstractWeatherCode> e
 
     /**
      * Parses the string containing the delivery time.
+     * If there is no delivery time, it parses the beginning of the validity time as delivery time.
      *
      * @param weatherCode The weather code.
      * @param time        the string to parse.
+     * @return true if the token was a real delivery time, false if it was a validity time.
      */
-    void parseDeliveryTime(final AbstractWeatherCode weatherCode, final String time) {
+    boolean parseDeliveryTime(final AbstractWeatherCode weatherCode, final String time) {
         weatherCode.setDay(Integer.parseInt(time.substring(0, 2)));
         int hours = Integer.parseInt(time.substring(2, 4));
-        int minutes = Integer.parseInt(time.substring(4, 6));
-        LocalTime t = LocalTime.of(hours, minutes);
-        weatherCode.setTime(t);
+        LocalTime t;
+        if (time.length() > 6 && time.contains("/")) {
+            t = LocalTime.of(hours, 0);
+            weatherCode.setTime(t);
+            return false;
+        } else {
+            int minutes = Integer.parseInt(time.substring(4, 6));
+            t = LocalTime.of(hours, minutes);
+            weatherCode.setTime(t);
+            return true;
+        }
     }
 
     /**

--- a/metarParser-parsers/src/main/java/io/github/mivek/parser/TAFParser.java
+++ b/metarParser-parsers/src/main/java/io/github/mivek/parser/TAFParser.java
@@ -84,9 +84,10 @@ public final class TAFParser extends AbstractWeatherCodeParser<TAF> {
         taf.setAirport(airport);
         taf.setMessage(code);
         // Day and time
-        parseDeliveryTime(taf, line1parts[i]);
+        if(parseDeliveryTime(taf, line1parts[i])) {
+            i++;
+        }
         // Validity Time
-        i++;
         taf.setValidity(parseValidity(line1parts[i]));
 
         // Handle rest of second line.

--- a/metarParser-parsers/src/test/java/io/github/mivek/parser/TAFParserTest.java
+++ b/metarParser-parsers/src/test/java/io/github/mivek/parser/TAFParserTest.java
@@ -955,4 +955,26 @@ class TAFParserTest extends AbstractWeatherCodeParserTest<TAF> {
         assertEquals(6, becmg2.getWind().getSpeed());
         assertEquals("KT", becmg2.getWind().getUnit());
     }
+
+    @Test
+    void testParseWithoutDeliveryTime() throws ParseException {
+        String code = """
+            TAF KNYL 2603/2703 20006KT 9999 SKC QNH2974INS
+            FM261000 14004KT 9999 SKC QNH2977INS
+            FM261700 17007KT 9999 SKC QNH2974INS
+            FM262100 19013KT 9999 SKC QNH2967INS AUTOMATED SENSOR METWATCH 2606 TIL 2614 TX42/2623Z TN24/2614Z
+            """;
+
+        TAF taf = parser.parse(code);
+
+        assertEquals("KNYL", taf.getStation());
+        assertEquals(26, taf.getDay());
+        assertEquals(3, taf.getTime().getHour());
+        assertEquals(0, taf.getTime().getMinute());
+
+        assertEquals(26, taf.getValidity().getStartDay());
+        assertEquals(3, taf.getValidity().getStartHour());
+        assertEquals(27, taf.getValidity().getEndDay());
+        assertEquals(3, taf.getValidity().getEndHour());
+    }
 }


### PR DESCRIPTION
When a TAF message does not contain a delivery time, the validity time is taken as delivery time.

Back-port of https://github.com/mivek/python-metar-taf-parser/pull/73