### PR TITLE
fix: improve runway parsing 

### DIFF
--- a/metarParser-parsers/src/main/java/io/github/mivek/command/metar/RunwayCommand.java
+++ b/metarParser-parsers/src/main/java/io/github/mivek/command/metar/RunwayCommand.java
@@ -164,6 +164,9 @@ public final class RunwayCommand implements Command {
      * @return Translated sentence representing the braking capacity.
      */
     private String parseDepositBrakingCapacity(final String input) {
+        if ("//".equals(input)) {
+            return messages.getString(DEPOSIT_BRAKING_CAPACITY_MAP.get(input));
+        }
         return messages.getString(DEPOSIT_BRAKING_CAPACITY_MAP.getOrDefault(input, "DepositBrakingCapacity.default"), Double.parseDouble(input) / 100);
     }
     @Override
@@ -171,4 +174,3 @@ public final class RunwayCommand implements Command {
         return Regex.find(GENERIC_RUNWAY_REGEX, input);
     }
 }
-

--- a/metarParser-parsers/src/test/java/io/github/mivek/command/metar/RunwayCommandTest.java
+++ b/metarParser-parsers/src/test/java/io/github/mivek/command/metar/RunwayCommandTest.java
@@ -156,9 +156,26 @@ class RunwayCommandTest {
     }
 
     @Test
-    void testParseRunwayWithIncompleteInfo() {
+    void testParseRunwayWithNoInfo() throws ParseException {
         Metar m = new Metar();
-        ParseException e = assertThrows(ParseException.class, () -> command.execute(m, "R16///////"));
-        assertEquals(Messages.getInstance().getString("ErrorCode.IncompleteRunwayInformation"), e.getErrorCode().getMessage());
+
+        command.execute(m, "R16///////");
+        assertThat(m.getRunways(), hasSize(1));
+        RunwayInfo ri = m.getRunways().get(0);
+        assertEquals("16", ri.getName());
+        assertEquals(DepositType.NOT_REPORTED, ri.getDepositType());
+        assertEquals(DepositCoverage.NOT_REPORTED, ri.getCoverage());
+    }
+
+    @Test
+    void testParseRunwayWithPartialInfo() throws ParseException {
+        Metar m = new Metar();
+
+        command.execute(m, "R88/29////");
+        assertThat(m.getRunways(), hasSize(1));
+        RunwayInfo ri = m.getRunways().get(0);
+        assertEquals("88", ri.getName());
+        assertEquals(DepositType.WET_WATER_PATCHES, ri.getDepositType());
+        assertEquals(DepositCoverage.FROM_51_TO_100, ri.getCoverage());
     }
 }


### PR DESCRIPTION
Improve runway parsing to properly handle cases when data is only partially provided.

- This change ensures that cases like `R88/29////` work. 
- Even cases like `R16///////` should ideally not lead to an error of the parsing and simply just provide the info that no values were reported

Thanks for taking a look.