### PR TITLE
fix(ci): fix sonar-pr-analysis for fork PRs

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -54,7 +54,6 @@ jobs:
           path: |
             **/target/classes/**
             **/target/test-classes/**
-            **/target/jacoco.xml
             **/target/site/jacoco/**
             **/target/surefire-reports/**
           retention-days: 1
@@ -72,6 +71,7 @@ jobs:
   generate-docs:
     runs-on: ubuntu-latest
     needs: verify
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -51,8 +51,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sonar-build
-          path: '**/target/'
+          path: |
+            **/target/classes/**
+            **/target/test-classes/**
+            **/target/jacoco.xml
+            **/target/site/jacoco/**
+            **/target/surefire-reports/**
           retention-days: 1
+          if-no-files-found: error
       - name: Upload PR metadata
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
@@ -60,6 +66,8 @@ jobs:
           name: pr-meta
           path: .pr-meta/
           retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
 
   generate-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonar-pr-analysis.yml
+++ b/.github/workflows/sonar-pr-analysis.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   sonar:
@@ -22,13 +23,6 @@ jobs:
           path: .pr-meta
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: sonar-build
-          path: .
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Read PR metadata
         id: pr-meta
         run: |
@@ -41,6 +35,13 @@ jobs:
         with:
           ref: ${{ steps.pr-meta.outputs.head_sha }}
           fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sonar-build
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Root cause

The `sonar-pr-analysis` workflow failed with:

```
AnalysisException: Your project contains .java files, please provide compiled classes with sonar.java.binaries property
```

The original step order in `sonar-pr-analysis.yml` was:
1. Download PR metadata
2. **Download build artifacts** ← before checkout!
3. Read PR metadata
4. **Checkout PR head** ← `clean: true` wiped the class files!

`actions/checkout` with default `clean: true` deletes all untracked files, which destroyed the downloaded `.class` files before Sonar could analyse them.

## Fixes

### `sonar-pr-analysis.yml` (committed in previous push)
- Added `actions: read` permission (required for cross-run artifact download)
- Moved **Download build artifacts** to _after_ **Checkout PR head**, so the checkout no longer wipes the compiled classes

### `maven-verify.yml`
- Guard `generate-docs` with `if: github.event_name == 'push'`: its failure on a PR would set the workflow conclusion to `failure`, silently suppressing the Sonar `workflow_run` trigger
- Remove dead artifact path `**/target/jacoco.xml` (JaCoCo writes to `target/site/jacoco/jacoco.xml`, already covered by the existing glob)