### PR TITLE
fix(sonar): fix security issues and correct S5738 suppression

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -10,7 +10,7 @@ jobs:
   sonarr:
     runs-on: ubuntu-latest
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             Please check on sonarcloud <https://sonarcloud.io/project/pull_requests_list?id=io.github.mivek%3AmetarParser> that the PR does not add any issue.

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -16,6 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Install semantic-release dependencies
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: Run semantic-release
         run: npx semantic-release
         env:

--- a/.github/workflows/validate-commit.yml
+++ b/.github/workflows/validate-commit.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Install commitlint
         run: |
-          npm install conventional-changelog-conventionalcommits@7.0.2
-          npm install commitlint@19.7.1
+          npm install --ignore-scripts conventional-changelog-conventionalcommits@7.0.2
+          npm install --ignore-scripts commitlint@19.7.1
 
       - name: Validate PR commits with commitlint
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/metarParser-commons/src/test/java/io/github/mivek/internationalization/MessagesTest.java
+++ b/metarParser-commons/src/test/java/io/github/mivek/internationalization/MessagesTest.java
@@ -21,21 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MessagesTest {
 
     @Test
-    @SuppressWarnings("java:S1874")
+    @SuppressWarnings("java:S5738")
     void testSetLocale() {
-        Messages.getInstance().setLocale(Locale.FRENCH);
+        Messages.getInstance().setLocale(Locale.FRENCH); // NOSONAR java:S5738
         assertEquals("peu", Messages.getInstance().getString("CloudQuantity.FEW"));
-        Messages.getInstance().setLocale(Locale.ENGLISH);
+        Messages.getInstance().setLocale(Locale.ENGLISH); // NOSONAR java:S5738
         assertEquals("few", Messages.getInstance().getString("CloudQuantity.FEW"));
-        Messages.getInstance().clearLocale();
+        Messages.getInstance().clearLocale(); // NOSONAR java:S5738
     }
 
     @Test
-    @SuppressWarnings("java:S1874")
+    @SuppressWarnings("java:S5738")
     void testClearLocale() {
-        Messages.getInstance().setLocale(Locale.FRENCH);
+        Messages.getInstance().setLocale(Locale.FRENCH); // NOSONAR java:S5738
         assertEquals("peu", Messages.getInstance().getString("CloudQuantity.FEW"));
-        Messages.getInstance().clearLocale();
+        Messages.getInstance().clearLocale(); // NOSONAR java:S5738
         assertDoesNotThrow(() -> Messages.getInstance().getString("CloudQuantity.FEW"));
     }
 


### PR DESCRIPTION
- Fix S5738: replace @SuppressWarnings("java:S1874") with "java:S5738" in MessagesTest — S5738 covers deprecated-for-removal methods
- Fix S8543 (release.yml): use npm ci --ignore-scripts to lock npm deps
- Fix S6505 (validate-commit.yml): add --ignore-scripts to npm install commands to prevent execution of arbitrary lifecycle scripts
- Fix S7637 (comment-pr.yml, lint-pr.yml): pin GitHub Actions to full commit SHAs to prevent supply-chain attacks
  - marocchino/sticky-pull-request-comment@v3 → SHA 0ea0beb (v3.0.4)
  - amannn/action-semantic-pull-request@v6.1.1 → SHA 48f2562