### PR TITLE
fix(entities): remove Objects.requireNonNull from AbstractTrend const…

### DIFF
--- a/metarParser-entities/src/main/java/io/github/mivek/model/trend/AbstractTrend.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/model/trend/AbstractTrend.java
@@ -3,7 +3,6 @@ package io.github.mivek.model.trend;
 import io.github.mivek.enums.WeatherChangeType;
 import io.github.mivek.model.AbstractWeatherContainer;
 import java.util.Locale;
-import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -22,7 +21,7 @@ public abstract class AbstractTrend extends AbstractWeatherContainer {
      */
     protected AbstractTrend(final WeatherChangeType type) {
         super();
-        this.type = Objects.requireNonNull(type);
+        this.type = type;
     }
 
     /**


### PR DESCRIPTION
…ructor

Removes the Objects.requireNonNull(type) call from the AbstractTrend constructor which could throw NullPointerException, leaving the object partially initialized and vulnerable to finalizer attacks (CT_CONSTRUCTOR_THROW).

The type field is assigned directly now. Since WeatherChangeType is an enum and all subclasses pass concrete values, null is never expected.