### PR TITLE
build(spotbugs): suppress CT_CONSTRUCTOR_THROW for three abstract class

### DIFF
--- a/metarParser-entities/src/main/java/io/github/mivek/model/trend/AbstractTrend.java
+++ b/metarParser-entities/src/main/java/io/github/mivek/model/trend/AbstractTrend.java
@@ -3,6 +3,7 @@ package io.github.mivek.model.trend;
 import io.github.mivek.enums.WeatherChangeType;
 import io.github.mivek.model.AbstractWeatherContainer;
 import java.util.Locale;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -21,7 +22,7 @@ public abstract class AbstractTrend extends AbstractWeatherContainer {
      */
     protected AbstractTrend(final WeatherChangeType type) {
         super();
-        this.type = type;
+        this.type = Objects.requireNonNull(type);
     }
 
     /**

--- a/spotbugs.xml
+++ b/spotbugs.xml
@@ -16,4 +16,16 @@
     <Match>
         <Bug code="EI2"/>
     </Match>
+    <Match>
+        <Class name="io.github.mivek.parser.AbstractWeatherContainerParser"/>
+        <Bug code="CT"/>
+    </Match>
+    <Match>
+        <Class name="io.github.mivek.parser.AbstractWeatherCodeParser"/>
+        <Bug code="CT"/>
+    </Match>
+    <Match>
+        <Class name="io.github.mivek.model.trend.AbstractTrend"/>
+        <Bug code="CT"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
[build(spotbugs): suppress CT_CONSTRUCTOR_THROW for three abstract cla…](https://github.com/mivek/MetarParser/commit/0060256efa3ca2420e21d04db1dabf6e8c615c11)

…sses

Suppress CT_CONSTRUCTOR_THROW for AbstractWeatherContainerParser,
AbstractWeatherCodeParser, and AbstractTrend.

All three are abstract (non-final) classes, but the finalizer-attack
vector is not exploitable: no finalize() methods exist in the codebase,
all concrete subclasses are final, no security-sensitive state is
involved, and Java 21 deprecates finalization.