### PR TITLE
fix(parser): accept report modifiers before the delivery time

### DIFF
--- a/metarParser-parsers/src/main/java/io/github/mivek/parser/MetarParser.java
+++ b/metarParser-parsers/src/main/java/io/github/mivek/parser/MetarParser.java
@@ -83,7 +83,7 @@ public final class MetarParser extends AbstractWeatherCodeParser<Metar> {
     }
 
     /**
-     * Parses the report-type prefix, station and delivery time.
+     * Parses the report-type prefix, the report modifiers, the station and the delivery time.
      *
      * @param m        the metar being built.
      * @param metarTab the tokenized message.
@@ -101,6 +101,8 @@ public final class MetarParser extends AbstractWeatherCodeParser<Metar> {
                 m.setReportType(io.github.mivek.enums.ReportType.SPECI);
                 startIndex = 1;
             }
+            // a modifier may follow the report type, as in "METAR COR LFPG 081130Z"
+            startIndex = parseLeadingFlags(m, metarTab, startIndex);
         }
         if (startIndex >= metarTab.length) {
             throw new ParseException(ErrorCodes.ERROR_CODE_INVALID_MESSAGE, ParseErrorType.STATION, null, startIndex);
@@ -112,11 +114,31 @@ public final class MetarParser extends AbstractWeatherCodeParser<Metar> {
         m.setStation(stationToken);
         m.setAirport(getAirportSupplier().get(stationToken));
         m.setMessage(code);
-        if (startIndex + 1 >= metarTab.length) {
-            throw new ParseException(ErrorCodes.ERROR_CODE_INVALID_MESSAGE, ParseErrorType.DELIVERY_TIME, null, startIndex + 1);
+        // it may also sit between the station and the delivery time, as in "LFPG COR 081130Z"
+        int timeIndex = parseLeadingFlags(m, metarTab, startIndex + 1);
+        if (timeIndex >= metarTab.length) {
+            throw new ParseException(ErrorCodes.ERROR_CODE_INVALID_MESSAGE, ParseErrorType.DELIVERY_TIME, null, timeIndex);
         }
-        parseDeliveryTime(m, metarTab[startIndex + 1], startIndex + 1);
-        return startIndex + 2;
+        parseDeliveryTime(m, metarTab[timeIndex], timeIndex);
+        return timeIndex + 1;
+    }
+
+    /**
+     * Consumes the report modifiers (COR, AMD, ...) preceding the delivery time. Modifiers placed
+     * after the delivery time are consumed by the body of the message instead.
+     *
+     * @param m        the metar being built.
+     * @param metarTab the tokenized message.
+     * @param index    the index to start at.
+     * @return the index of the first token that is not a modifier.
+     */
+    private int parseLeadingFlags(final Metar m, final String[] metarTab, final int index) {
+        int flagIndex = index;
+        // index 0 holds the report type or the station, never a modifier
+        while (flagIndex > 0 && flagIndex < metarTab.length && parseFlags(m, metarTab[flagIndex])) {
+            flagIndex++;
+        }
+        return flagIndex;
     }
 
     /**

--- a/metarParser-parsers/src/test/java/io/github/mivek/parser/MetarParserTest.java
+++ b/metarParser-parsers/src/test/java/io/github/mivek/parser/MetarParserTest.java
@@ -507,4 +507,67 @@ class MetarParserTest extends AbstractWeatherCodeParserTest<Metar> {
         assertEquals(ParseErrorType.DELIVERY_TIME, e.getType());
     }
 
+    @Test
+    void testParseWithCorrectionBetweenStationAndDeliveryTime() throws ParseException {
+        Metar m = parser.parse("MRLB COR 071700Z 11013KT 9999 FEW045 34/22 A2983");
+
+        assertTrue(m.isCorrected());
+        assertEquals("MRLB", m.getStation());
+        assertEquals(Integer.valueOf(7), m.getDay());
+        assertEquals(17, m.getTime().getHour());
+        assertEquals(0, m.getTime().getMinute());
+        assertEquals(Integer.valueOf(34), m.getTemperature());
+    }
+
+    @Test
+    void testParseWithCorrectionBetweenReportTypeAndStation() throws ParseException {
+        Metar m = parser.parse("METAR COR LFPG 081130Z 00000KT 0350 FG SCT000 M01/M01 Q1026");
+
+        assertTrue(m.isCorrected());
+        assertEquals(ReportType.METAR, m.getReportType());
+        assertEquals("LFPG", m.getStation());
+        assertEquals(Integer.valueOf(8), m.getDay());
+        assertEquals(11, m.getTime().getHour());
+        assertEquals(30, m.getTime().getMinute());
+    }
+
+    @Test
+    void testParseWithCorrectionAfterDeliveryTime() throws ParseException {
+        Metar m = parser.parse("MRLB 071700Z COR 11013KT 9999 FEW045 34/22 A2983");
+
+        assertTrue(m.isCorrected());
+        assertEquals(Integer.valueOf(7), m.getDay());
+        assertEquals(Integer.valueOf(34), m.getTemperature());
+    }
+
+    @Test
+    void testParseWithoutCorrectionIsNotFlaggedAsCorrected() throws ParseException {
+        Metar m = parser.parse("MRLB 071700Z 11013KT 9999 FEW045 34/22 A2983");
+
+        assertFalse(m.isCorrected());
+        assertEquals(Integer.valueOf(7), m.getDay());
+    }
+
+    @Test
+    void testParseWithModifierButWithoutDeliveryTimeThrowsDeliveryTimeError() {
+        ParseException e = assertThrows(ParseException.class, () -> parser.parse("LFPG COR"));
+        assertEquals(ParseErrorType.DELIVERY_TIME, e.getType());
+        assertEquals(2, e.getPosition());
+    }
+
+    @Test
+    void testParseWithModifierButWithoutStationThrowsStationError() {
+        ParseException e = assertThrows(ParseException.class, () -> parser.parse("METAR COR"));
+        assertEquals(ParseErrorType.STATION, e.getType());
+        assertEquals(2, e.getPosition());
+    }
+
+    @Test
+    void testParseKeepsAutoAsStationWhenItLeadsTheMessage() {
+        // a modifier is only expected after the report type or the station, never in first position
+        ParseException e = assertThrows(ParseException.class, () -> parser.parse("AUTO 11013KT 9999"));
+        assertEquals(ParseErrorType.DELIVERY_TIME, e.getType());
+        assertEquals("11013KT", e.getOffendingToken());
+    }
+
 }


### PR DESCRIPTION
Fixes parsing of a `COR` correction indicator placed before the delivery time group.

`parseIdentification` expected the station at a fixed offset after the optional `METAR`/`SPECI` prefix, and the delivery time immediately after the station. Any modifier in between was parsed as a station or as a time and threw a `ParseException`.

Two legal placements were affected:

```
MRLB COR 071700Z 11013KT 9999 FEW045 SCT100 34/22 A2983          # NOAA metars.cache.xml
METAR COR LFPG 081130Z 00000KT 0350 FG SCT000 M01/M01 Q1026      # ICAO Annex 3, App. 3
```

The library already models this: `Flag.COR` and `isCorrected()` exist, and `parseFlags` handles a `COR` that *follows* the delivery time. This change reuses `parseFlags` for the tokens preceding the delivery time, so all three placements behave the same and `isCorrected()` is set consistently. No new API.

Flag skipping is disabled at index 0, where only a report type or a station can appear -- otherwise `AUTO`, which is both a `Flag` and a four-letter token matching the station pattern, would be consumed as a modifier.

**Tests**

7 added to `MetarParserTest` covering the three `COR` placements, the uncorrected baseline, both truncated-message error paths, and the `AUTO`-at-index-0 guard.

`mvn verify` green: 661 tests, Checkstyle, SpotBugs and JaCoCo gates all passing.
